### PR TITLE
fix: update metadata issue

### DIFF
--- a/python/invariant_sdk/types/update_dataset_metadata.py
+++ b/python/invariant_sdk/types/update_dataset_metadata.py
@@ -25,7 +25,7 @@ class MetadataUpdate(BaseModel):
     )
 
     # Enable strict type checking.
-    model_config = ConfigDict(strict=True, populate_by_name=True)
+    model_config = ConfigDict(strict=True, populate_by_name=True, extra="forbid")
 
     @field_validator("accuracy")
     @staticmethod


### PR DESCRIPTION
Now when using `create_request_and_update_dataset_metadata` with invalid metadata, `ValidationError` is raised